### PR TITLE
add `SMB_MAX_SIZE_MB` env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     PUID=0 \
     SMB_NAME='Time Machine' \
     SMB_USER=dog \
-    SMB_PASSWORD=dog
+    SMB_PASSWORD=dog \
+    SMB_MAX_SIZE_MB=0
 VOLUME ["/share"]
 
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Why? Because I like dogs.
 
 ## Fancy
 
-| Environmental Variables   | Description          |
-| ------------------------- | -------------------- |
-| `SMB_NAME='Time Machine'` | what you see from 💻 |
-| `SMB_USER=dog`            | your login           |
-| `SMB_PASSWORD=dog`        | your password        |
-| `PGID=0`                  | user gid (advanced)  |
-| `PUID=0`                  | user uid (advanced)  |
+| Environmental Variables   | Description                            |
+| ------------------------- | --------------------                   |
+| `SMB_NAME='Time Machine'` | what you see from 💻                   |
+| `SMB_USER=dog`            | your login                             |
+| `SMB_PASSWORD=dog`        | your password                          |
+| `SMB_MAX_SIZE_MB=0`       | max reported share size (0 = no limit) |
+| `PGID=0`                  | user gid (advanced)                    |
+| `PUID=0`                  | user uid (advanced)                    |
 
 ## Docker Compose
 

--- a/root/etc/cont-init.d/00-envsubst.sh
+++ b/root/etc/cont-init.d/00-envsubst.sh
@@ -13,4 +13,4 @@ sub() {
 
 export HOST_NAME="$(hostname)"
 
-sub '${SMB_USER},${SMB_NAME}' /etc/samba/smb.conf
+sub '${SMB_USER},${SMB_NAME},${SMB_MAX_SIZE_MB}' /etc/samba/smb.conf

--- a/root/etc/samba/smb.conf
+++ b/root/etc/samba/smb.conf
@@ -16,6 +16,7 @@
   acl allow execute always = yes
   log file = /var/log/samba/%m.log
   max log size = 1000
+  max disk size = ${SMB_MAX_SIZE_MB}
 
   # Special configuration for Apple's Time Machine
   fruit:model = MacPro


### PR DESCRIPTION
If specified (and not 0), this env variable provides a maximum size (in megabytes)
that the samba server will report to Time Machine.