### PR TITLE
Remove --log-stdout arg

### DIFF
--- a/root/etc/services.d/sambd/run
+++ b/root/etc/services.d/sambd/run
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 
-exec /usr/sbin/smbd --foreground --no-process-group --log-stdout
+exec /usr/sbin/smbd --foreground --no-process-group


### PR DESCRIPTION
Remove " --log-stdout" from "sambd" "run" file as it was causing run issues