### PR TITLE
--log-stdout was renamed to --debug-stdout in samba 4.15.0

### DIFF
--- a/root/etc/services.d/nmbd/run
+++ b/root/etc/services.d/nmbd/run
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 
-exec /usr/sbin/nmbd --foreground --no-process-group --log-stdout
+exec /usr/sbin/nmbd --foreground --no-process-group --debug-stdout

--- a/root/etc/services.d/sambd/run
+++ b/root/etc/services.d/sambd/run
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 
-exec /usr/sbin/smbd --foreground --no-process-group --log-stdout
+exec /usr/sbin/smbd --foreground --no-process-group --debug-stdout


### PR DESCRIPTION
Samba doesn't start anymore. 4.15.0 release notes mention renaming log-stdout to debug-stdout.

time-machine  | Invalid options
time-machine  |
time-machine  | Usage: nmbd [-?DiFV] [-?|--help] [--usage] [-H|--hosts=STRING]
time-machine  |         [-p|--port=INT] [-d|--debuglevel=DEBUGLEVEL] [--debug-stdout]
time-machine  |         [-s|--configfile=CONFIGFILE] [--option=name=value]
time-machine  |         [-l|--log-basename=LOGFILEBASE] [--leak-report] [--leak-report-full]
time-machine  |         [-D|--daemon] [-i|--interactive] [-F|--foreground]
time-machine  |         [--no-process-group] [-V|--version]
time-machine  |
time-machine  | Invalid option --log-stdout: unknown option