### PR TITLE
fix constant restart error: 00-smb.sh exits with error code 9

### DIFF
--- a/root/etc/cont-init.d/00-smb.sh
+++ b/root/etc/cont-init.d/00-smb.sh
@@ -6,8 +6,13 @@ set -o pipefail
 
 GROUP_NAME='time-machine-users'
 
-groupadd --non-unique --gid "$PGID" "$GROUP_NAME"
-useradd --system --non-unique --gid "$GROUP_NAME" --uid "$PUID" "$SMB_USER"
+if ! getent group "$GROUP_NAME" > /dev/null 2>&1; then
+  groupadd --non-unique --gid "$PGID" "$GROUP_NAME"
+fi
+
+if ! id -u "$SMB_USER" > /dev/null 2>&1; then
+  useradd --system --non-unique --gid "$GROUP_NAME" --uid "$PUID" "$SMB_USER"
+fi
 
 
 printf '%s\n%s\n' "$SMB_PASSWORD" "$SMB_PASSWORD" | smbpasswd -s -a "$SMB_USER"

--- a/root/etc/samba/smb.conf
+++ b/root/etc/samba/smb.conf
@@ -18,7 +18,7 @@
   max log size = 1000
 
   # Special configuration for Apple's Time Machine
-  fruit:model = MacPro
+  fruit:model = TimeCapsule8,119
   fruit:advertise_fullsync = true
   fruit:aapl = yes
   fruit:time machine = yes


### PR DESCRIPTION
only add group and user if not already exists. otherwise only first execution works, after that container will constantly restart